### PR TITLE
shorten the filter tag length to 38 char + non whitespace

### DIFF
--- a/src/views/CFilter.vue
+++ b/src/views/CFilter.vue
@@ -28,7 +28,7 @@
           v-for="f in activeFilters"
           :key="`active-${f.key}-${f.value}`"
         >
-          {{ f.label }}: {{ getLabelValue(f) }}
+          <span class="has-ellipsis">{{ f.label }}: {{ getLabelValue(f) }}</span>
           <button class="delete" @click="removeFilter(f)"></button>
         </div>
       </div>
@@ -50,10 +50,13 @@ export default {
     getLabelValue(f) {
       return Object.keys(f.values)
         .find((key) => f.values[key] === parseInt(f.value))
-        .replace(/^(.{38}[^\s]*).*/, "$1");
     },
   },
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.tag .has-ellipsis {
+  max-width: calc(100vw - 110px);
+}
+</style>


### PR DESCRIPTION
This pull request adds a regular expression to the `getLabelValue` method to shorten the label for questions allowing the close button to show on mobile screens:

<img width="403" alt="Screen Shot 2021-04-22 at 11 23 07 AM" src="https://user-images.githubusercontent.com/286093/115766904-5fd4ce00-a35d-11eb-8362-cccf53587772.png">
