### PR TITLE
add negative filter to the assessor

### DIFF
--- a/src/store/modules/assessments.js
+++ b/src/store/modules/assessments.js
@@ -50,9 +50,10 @@ const getters = {
   filteredAssessments: (state, _, rootState, rootGetters) => {
     let filtered = rootGetters['assessments/fullAssessments']
     state.activeFilters.forEach((current) => {
-      filtered = filtered.filter((el) =>
-        comparisons[current.comparison](current.value, el[current.key], el)
-      )
+      filtered = filtered.filter((el) => {
+        let currentComparison = current.negative ? `not${current.comparison}` : current.comparison
+        return comparisons[currentComparison](current.value, el[current.key], el)
+      })
     })
     return comparisons[state.activePrefilter.v](filtered)
   },

--- a/src/utils/comparisons.js
+++ b/src/utils/comparisons.js
@@ -3,6 +3,7 @@ import shuffle from '@/utils/shuffle'
 const comparisions = {
   sameInt: (a, v) => parseInt(a) === parseInt(v),
   same: (a, v) => a === v,
+  notsame: (a, v) => a !== v,
   alreadyReviewed: (a, v, el) => (el.reviewed !== undefined) ? (a === v) : (!a),
   sameAvg: (a, v, el) => {
     v = Math.round((el.auditability_rating + el.feasibility_rating + el.impact_rating) / 3);

--- a/src/views/CFilter.vue
+++ b/src/views/CFilter.vue
@@ -19,6 +19,11 @@
           </b-select>
         </b-field>
         <b-field expanded :label="v.label" v-if="v.type === 'autocomplete'">
+          <b-checkbox
+            v-if="v.label === 'Assessor'"
+            v-model="v.negative">
+            Not
+          </b-checkbox>
           <b-autocomplete
               v-model="search[v.key]"
               :data="filteredDataArray(v.values, v.key)"
@@ -40,7 +45,7 @@
           v-for="f in activeFilters"
           :key="`active-${f.key}-${f.value}`"
         >
-          <span class="has-ellipsis">{{ f.label }}: {{ getLabelValue(f) }}</span>
+          <span class="has-ellipsis">{{ (f.negative) ? 'Not' : '' }} {{ f.label }}: {{ getLabelValue(f) }}</span>
           <button class="delete" @click="removeFilter(f)"></button>
         </div>
       </div>

--- a/src/views/Conditions.vue
+++ b/src/views/Conditions.vue
@@ -84,6 +84,7 @@ export default {
       categories: categories,
       interval: false,
       filterVisible: false,
+      negativeAssessorFilter: false,
       prefilters: [
         { label: "Random", v: "random" },
         { label: "Low reviewed (from other vCAs)", v: "lowReviewed" },
@@ -167,6 +168,7 @@ export default {
           type: 'autocomplete',
           value: "",
           values: this.assessors,
+          negative: this.negativeAssessorFilter
         },
         lenLess: {
           key: "note",


### PR DESCRIPTION
_Purpose of the PR:_ 
currently there's no way to do a negative search. For example when you're a vCA you don't want to review your assessments so you'd like to exclude yourself, but you can't because you can't search for every assessor but yourself. This PR enables vCAs to exclude themselves, when searching.

_Problems:_
couldn't run `yarn lint`, because of some errors: `'csvHeaders' is not defined`

_Solution:_
add negative assessor filter

>Note: the approach will allow to add more negative filters for other fields as well as long as they keep the `not` keyword followed by the filter name. E.g. filter: `same`, opposite filter name would be `notsame`.

UI could be better, and I would be happy for some guidance on how to do it better.

![Screenshot from 2022-02-28 04-09-01](https://user-images.githubusercontent.com/5918351/155913082-4f299a41-d47b-464d-812f-f684638a93b8.png)

